### PR TITLE
Don't add offscreen cars

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${command:cmake.launchTargetPath}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "/bin",
+            "environment": [
+                {
+                    // add the directory where our target was built to the PATHs
+                    // it gets resolved by CMake Tools:
+                    "name": "PATH",
+                    "value": "$PATH:${command:cmake.launchTargetDirectory}"
+                }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/sl.c
+++ b/sl.c
@@ -190,7 +190,7 @@ int add_D51(int x)
         = {CAR01, CAR02, CAR03, CAR04, CAR05,
            CAR06, CAR07, CAR08, CAR09, CAR10, COALDEL};
 
-    int y, i, j, cars, dy = 0;
+    int y, i, j, cars, pos, dy = 0;
     struct dirent **namelist;
     char carName[32];
 
@@ -209,10 +209,15 @@ int add_D51(int x)
             my_mvaddstr(y + i + dy, x + 53, coal[i]);
         }
         for (j = 0; j < cars; ++j) {
-            if (D51LENGTH + x + 32 * (j + 1) > 0) {
-                snprintf(carName, 32, car[i], namelist[j]->d_name);
-                my_mvaddstr(y + i + dy, x + 53 + 29 * (j + 1), carName);
+            pos = D51LENGTH + x + 29 * (j + 1);
+            if (pos < 0) {
+                continue;
+            } else if (pos > COLS + D51LENGTH) {
+                break;
             }
+
+            snprintf(carName, 32, car[i], namelist[j]->d_name);
+            my_mvaddstr(y + i + dy, x + 53 + 29 * (j + 1), carName);
         }
     }
 

--- a/sl.c
+++ b/sl.c
@@ -209,8 +209,10 @@ int add_D51(int x)
             my_mvaddstr(y + i + dy, x + 53, coal[i]);
         }
         for (j = 0; j < cars; ++j) {
-            snprintf(carName, 32, car[i], namelist[j]->d_name);
-            my_mvaddstr(y + i + dy, x + 53 + 29 * (j + 1), carName);
+            if (D51LENGTH + x + 32 * (j + 1) > 0) {
+                snprintf(carName, 32, car[i], namelist[j]->d_name);
+                my_mvaddstr(y + i + dy, x + 53 + 29 * (j + 1), carName);
+            }
         }
     }
 


### PR DESCRIPTION
- Attempt to fix #1 
- Add check on cars position to stop rendering it once it's gone off the left side of the screen
- Add a check to stop trying to load cars once we've passed the right side of the screen with cars