### PR TITLE
Use environment vcpkg

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-    "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
-    "files.associations": {
-        "ranges": "c"
-    },
-    "cmake.configureEnvironment": {
-        "CMAKE_TOOLCHAIN_FILE": "${userHome}/.vcpkg/scripts/buildsystems/vcpkg.cmake"
-    }
+  "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+  "files.associations": {
+    "ranges": "c"
+  },
+  "cmake.configureEnvironment": {
+    "CMAKE_TOOLCHAIN_FILE": "${env:VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+  }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,5 +6,6 @@
       "name": "pdcurses",
       "platform": "windows"
     }
-  ]
+  ],
+  "builtin-baseline": "b3e0a1e625a0cc00073efb763e39088e5b75939e"
 }


### PR DESCRIPTION
- Use the environment variable for VCPKG_ROOT to find build integration script
- Add baseline for use with VS built in vcpkg