### PR TITLE
Add caching for Cargo and Yarn in CI workflows

### DIFF
--- a/.github/workflows/fedora-build.yml
+++ b/.github/workflows/fedora-build.yml
@@ -10,7 +10,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+      - name: Cache Cargo Registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ubuntu-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - name: Build and Test
         uses: devcontainers/ci@v0.3
         with:

--- a/.github/workflows/posix-build.yml
+++ b/.github/workflows/posix-build.yml
@@ -12,13 +12,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+      - name: Cache Cargo Registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - name: Build Debug
         run: cargo build
-
       - name: Build Release
         run: cargo build --release
-
       - name: Test
         run: |
           ./target/debug/sl -h

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -11,6 +11,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Cache Yarn
+        uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+            yarn.lock
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
+
       - name: Install Dependencies
         run: |
           rustup target add wasm32-unknown-unknown

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -13,41 +13,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+      - name: Cache Cargo Registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - name: Install toolchain
         run: rustup target install ${{ matrix.target }}-pc-windows-msvc
-
       - name: Build Debug
         run: cargo build --target=${{ matrix.target }}-pc-windows-msvc
-
       - name: Build Release
         run: cargo build --target=${{ matrix.target }}-pc-windows-msvc --release
-
-      - name: Build Installer
+      - name: Build and Process Installer
+        id: installer_build
         working-directory: ${{github.workspace}}/target
+        shell: bash
         run: |
           cmake .. -DARCH="${{ matrix.target }}"
           cpack -C Release
-
-      - name: Rename Installer for aarch64
-        if: matrix.target == 'aarch64'
-        working-directory: ${{github.workspace}}/target
-        shell: bash
-        run: |
-          INSTALLER=$(ls sl-*.exe)
-          NEW_INSTALLER=$(echo $INSTALLER | sed 's/win64/woa64/')
-          mv $INSTALLER $NEW_INSTALLER
-
-      - name: Find Installer
-        id: installer
-        working-directory: ${{github.workspace}}/target
-        shell: bash
-        run: |
+          if [ "${{ matrix.target }}" == "aarch64" ]; then
+            INSTALLER=$(ls sl-*.exe)
+            NEW_INSTALLER=$(echo $INSTALLER | sed 's/win64/woa64/')
+            mv $INSTALLER $NEW_INSTALLER
+          fi
           INSTALLER=$(ls sl-*.exe)
           echo "installer=${INSTALLER}" >> $GITHUB_OUTPUT
-
       - name: Upload Installer
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.installer.outputs.installer }}
-          path: target/${{ steps.installer.outputs.installer }}
+          name: ${{ steps.installer_build.outputs.installer }}
+          path: target/${{ steps.installer_build.outputs.installer }}


### PR DESCRIPTION
Introduce caching for Cargo and Yarn in CI workflows to improve build efficiency and reduce dependency installation time.