### PR TITLE
fix: offline mode for web page

### DIFF
--- a/apps/page/manifest.json
+++ b/apps/page/manifest.json
@@ -2,13 +2,13 @@
   "name": "SL - Steam Locomotive Terminal Animation",
   "short_name": "SL Demo",
   "description": "SL (Steam Locomotive) terminal animation demo",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#000000",
   "icons": [
     {
-      "src": "/favicon.svg",
+      "src": "./favicon.svg",
       "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "any maskable"

--- a/apps/page/src/components/home/Form.tsx
+++ b/apps/page/src/components/home/Form.tsx
@@ -74,7 +74,7 @@ const Form = ({ state, dispatch }: FormProps) => {
     (e: JSX.TargetedEvent<HTMLInputElement>) => {
       const newColor = e.currentTarget.value;
       dispatch({ type: 'SET_FONT_COLOR', payload: newColor });
-      
+
       // Debounce aria-live announcement
       clearTimeout(fontColorTimerRef.current);
       fontColorTimerRef.current = window.setTimeout(() => {
@@ -88,7 +88,7 @@ const Form = ({ state, dispatch }: FormProps) => {
     (e: JSX.TargetedEvent<HTMLInputElement>) => {
       const newColor = e.currentTarget.value;
       dispatch({ type: 'SET_BACKGROUND_COLOR', payload: newColor });
-      
+
       // Debounce aria-live announcement
       clearTimeout(bgColorTimerRef.current);
       bgColorTimerRef.current = window.setTimeout(() => {
@@ -129,15 +129,24 @@ const Form = ({ state, dispatch }: FormProps) => {
         <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
           <input id="font-color-input" type="color" value={state.fontColor} onChange={handleFontColorChange} />
           <span>{state.fontColor}</span>
-          <span aria-live="polite" aria-atomic="true" className="sr-only">Font color: {announcedFontColor}</span>
+          <span aria-live="polite" aria-atomic="true" className="sr-only">
+            Font color: {announcedFontColor}
+          </span>
         </div>
       </label>
       <label htmlFor="background-color-input">
         <div>Background Color</div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
-          <input id="background-color-input" type="color" value={state.backgroundColor} onChange={handleBackgroundColorChange} />
+          <input
+            id="background-color-input"
+            type="color"
+            value={state.backgroundColor}
+            onChange={handleBackgroundColorChange}
+          />
           <span>{state.backgroundColor}</span>
-          <span aria-live="polite" aria-atomic="true" className="sr-only">Background color: {announcedBgColor}</span>
+          <span aria-live="polite" aria-atomic="true" className="sr-only">
+            Background color: {announcedBgColor}
+          </span>
         </div>
       </label>
     </div>

--- a/apps/page/src/components/home/Home.tsx
+++ b/apps/page/src/components/home/Home.tsx
@@ -68,9 +68,9 @@ const Home = () => {
       </p>
       <p>
         Visit our{' '}
-        <a 
-          href="https://github.com/scaryrawr/sl" 
-          target="_blank" 
+        <a
+          href="https://github.com/scaryrawr/sl"
+          target="_blank"
           rel="noopener noreferrer"
           aria-label="GitHub repository (opens in new tab)"
         >

--- a/apps/page/src/components/home/Installation.tsx
+++ b/apps/page/src/components/home/Installation.tsx
@@ -4,12 +4,7 @@ const Installation = () => (
     <h3>macOS and x64 Linux</h3>
     <p>
       Using{' '}
-      <a 
-        href="https://brew.sh" 
-        target="_blank" 
-        rel="noopener noreferrer"
-        aria-label="Homebrew (opens in new tab)"
-      >
+      <a href="https://brew.sh" target="_blank" rel="noopener noreferrer" aria-label="Homebrew (opens in new tab)">
         homebrew
       </a>
       :
@@ -18,9 +13,9 @@ const Installation = () => (
     <h3>Fedora Linux</h3>
     <p>
       Using{' '}
-      <a 
-        href="https://copr.fedorainfracloud.org/coprs/scaryrawr/sl/" 
-        target="_blank" 
+      <a
+        href="https://copr.fedorainfracloud.org/coprs/scaryrawr/sl/"
+        target="_blank"
         rel="noopener noreferrer"
         aria-label="Copr (opens in new tab)"
       >
@@ -35,9 +30,9 @@ sudo dnf install sl`}
     <h3>Windows</h3>
     <p>
       Download the{' '}
-      <a 
-        href="https://github.com/scaryrawr/sl/releases/latest" 
-        target="_blank" 
+      <a
+        href="https://github.com/scaryrawr/sl/releases/latest"
+        target="_blank"
         rel="noopener noreferrer"
         aria-label="Latest release (opens in new tab)"
       >

--- a/apps/page/src/components/terminal.tsx
+++ b/apps/page/src/components/terminal.tsx
@@ -255,8 +255,8 @@ const Terminal = ({ title, terminalRef: externalRef, fontColor = '#0f0', backgro
           <span style={styles.button}>×</span>
         </div>
       </div>
-      <div 
-        ref={terminalRef} 
+      <div
+        ref={terminalRef}
         style={terminalStyle}
         role="img"
         aria-label="Animated ASCII art train moving across terminal screen"


### PR DESCRIPTION
## Summary
Fix offline mode for the SL web page PWA.

## Problem
The service worker was failing to register, preventing the page from working offline. Additionally, stale WASM files could accumulate in the cache.

## Changes
- **Service Worker**: Bump cache version to v2, add cleanup logic for stale WASM files
- **Manifest**: Use relative paths for GitHub Pages compatibility
- **Build**: Select newest WASM file by mtime to avoid stale artifacts
- **slTerminal**: Add error handling for WASM loading failures
- **Style**: Format JSX components with prettier

## Testing
Verified using Playwright:
- ✅ Service worker registers successfully
- ✅ All assets cached in `sl-page-v2`
- ✅ Page loads fully offline
- ✅ Train animation runs from cached WASM
- ✅ No console errors

Before fix: Service worker failed to register with script evaluation error, offline navigation failed with ERR_INTERNET_DISCONNECTED.