### PR TITLE
Fix offline page service worker behavior

### DIFF
--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -19,7 +19,14 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - name: Install NSIS
-        run: choco install nsis
+        run: |
+          winget install --id NSIS.NSIS --silent --accept-source-agreements --accept-package-agreements
+          if (Test-Path "C:\Program Files (x86)\NSIS") {
+            Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\NSIS"
+          } elseif (Test-Path "C:\Program Files\NSIS") {
+            Add-Content $env:GITHUB_PATH "C:\Program Files\NSIS"
+          }
+        shell: pwsh
       - name: Install toolchain
         run: rustup target install ${{ matrix.target }}-pc-windows-msvc
       - name: Build Debug

--- a/apps/page/package.json
+++ b/apps/page/package.json
@@ -9,8 +9,11 @@
     "build": "bun build.ts",
     "dev": "bun dev.ts",
     "format": "prettier \"src/**/*.{ts,tsx,json,md}\" --write",
+    "playwright:install": "bunx playwright install chromium",
+    "serve:playwright": "bun ./playwright-server.mjs",
     "start": "bunx http-server ./lib/",
-    "test": "bun test",
+    "test": "bun test ./src",
+    "test:e2e": "cd ../.. && bun run build:websl && bun run build:page && cd apps/page && bunx playwright test",
     "typecheck": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
@@ -18,6 +21,7 @@
     "websl": "*"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/bun": "1.3.3",
     "typescript": "^5.9.3"
   },

--- a/apps/page/playwright-server.mjs
+++ b/apps/page/playwright-server.mjs
@@ -1,0 +1,61 @@
+import path from 'node:path';
+
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
+const basePath = '/sl';
+const libDir = path.join(import.meta.dir, 'lib');
+
+const contentTypes = new Map([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.wasm', 'application/wasm']
+]);
+
+const resolvePathname = (pathname) => {
+  if (pathname === `${basePath}/` || pathname === `${basePath}/index.html`) {
+    return path.join(libDir, 'index.html');
+  }
+
+  if (pathname === `${basePath}/embed` || pathname === `${basePath}/embed.html`) {
+    return path.join(libDir, 'embed.html');
+  }
+
+  if (!pathname.startsWith(`${basePath}/`)) {
+    return null;
+  }
+
+  return path.join(libDir, pathname.slice(`${basePath}/`.length));
+};
+
+const server = Bun.serve({
+  hostname: '127.0.0.1',
+  port,
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (url.pathname === basePath) {
+      return Response.redirect(new URL(`${basePath}/`, url).toString(), 302);
+    }
+
+    const filePath = resolvePathname(url.pathname);
+    if (!filePath) {
+      return new Response('Not found', { status: 404 });
+    }
+
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) {
+      return new Response('Not found', { status: 404 });
+    }
+
+    const headers = new Headers();
+    const contentType = contentTypes.get(path.extname(filePath));
+    if (contentType) {
+      headers.set('Content-Type', contentType);
+    }
+
+    return new Response(file, { headers });
+  }
+});
+
+console.log(`Playwright server listening on http://127.0.0.1:${server.port}${basePath}/`);

--- a/apps/page/playwright-server.mjs
+++ b/apps/page/playwright-server.mjs
@@ -28,7 +28,11 @@ const resolvePathname = (pathname) => {
   return path.join(libDir, pathname.slice(`${basePath}/`.length));
 };
 
-const isPathSafe = (resolvedPath) => resolvedPath.startsWith(libDir + path.sep);
+const isPathSafe = (resolvedPath) => {
+  const normalizedPath = path.resolve(resolvedPath);
+  const normalizedLib = path.resolve(libDir) + path.sep;
+  return normalizedPath.startsWith(normalizedLib);
+};
 
 const server = Bun.serve({
   hostname: '127.0.0.1',

--- a/apps/page/playwright-server.mjs
+++ b/apps/page/playwright-server.mjs
@@ -28,6 +28,8 @@ const resolvePathname = (pathname) => {
   return path.join(libDir, pathname.slice(`${basePath}/`.length));
 };
 
+const isPathSafe = (resolvedPath) => resolvedPath.startsWith(libDir + path.sep);
+
 const server = Bun.serve({
   hostname: '127.0.0.1',
   port,
@@ -39,7 +41,7 @@ const server = Bun.serve({
     }
 
     const filePath = resolvePathname(url.pathname);
-    if (!filePath) {
+    if (!filePath || !isPathSafe(filePath)) {
       return new Response('Not found', { status: 404 });
     }
 

--- a/apps/page/playwright.config.mjs
+++ b/apps/page/playwright.config.mjs
@@ -1,0 +1,25 @@
+import { defineConfig } from '@playwright/test';
+
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
+
+export default defineConfig({
+  testDir: './playwright',
+  testMatch: '**/*.e2e.js',
+  reporter: 'line',
+  workers: 1,
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    browserName: 'chromium',
+    headless: true,
+    screenshot: 'off',
+    serviceWorkers: 'allow',
+    trace: 'off',
+    video: 'off'
+  },
+  webServer: {
+    command: 'bun run serve:playwright',
+    port,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000
+  }
+});

--- a/apps/page/playwright/offline.e2e.js
+++ b/apps/page/playwright/offline.e2e.js
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+
+const waitForServiceWorkerControl = async (page) => {
+  await page.evaluate(async () => {
+    if (!('serviceWorker' in navigator)) {
+      throw new Error('Service workers are not supported in this browser');
+    }
+
+    await navigator.serviceWorker.ready;
+
+    if (navigator.serviceWorker.controller) {
+      return;
+    }
+
+    await new Promise((resolve) => {
+      navigator.serviceWorker.addEventListener('controllerchange', () => resolve(), { once: true });
+    });
+  });
+};
+
+test('loads the home page offline from the bare project path', async ({ context, page }) => {
+  const requestedOutsideProjectPath = [];
+  let origin = '';
+
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (origin && url.origin === origin && url.pathname !== '/sl' && !url.pathname.startsWith('/sl/')) {
+      requestedOutsideProjectPath.push(url.pathname);
+    }
+  });
+
+  await page.goto('/sl/', { waitUntil: 'networkidle' });
+  await expect(page.getByRole('heading', { name: 'Welcome to the SL Project' })).toBeVisible();
+
+  origin = new URL(page.url()).origin;
+  await waitForServiceWorkerControl(page);
+
+  await context.setOffline(true);
+
+  await page.evaluate(() => {
+    const iframe = document.createElement('iframe');
+    iframe.id = 'offline-frame';
+    iframe.src = '/sl';
+    document.body.appendChild(iframe);
+  });
+
+  await expect
+    .poll(() => page.frames().find((frame) => frame !== page.mainFrame() && frame.url() === `${origin}/sl/`)?.url() ?? '')
+    .toBe(`${origin}/sl/`);
+
+  const frame = page.frames().find((candidate) => candidate !== page.mainFrame() && candidate.url() === `${origin}/sl/`);
+  if (!frame) {
+    throw new Error('Offline navigation frame did not load the canonical /sl/ URL');
+  }
+
+  await expect(frame.getByRole('heading', { name: 'Welcome to the SL Project' })).toBeVisible();
+  expect(requestedOutsideProjectPath).not.toContain('/index.js');
+  expect(requestedOutsideProjectPath).not.toContain('/manifest.json');
+});

--- a/apps/page/src/service-worker-build.test.ts
+++ b/apps/page/src/service-worker-build.test.ts
@@ -11,6 +11,8 @@ describe('service worker build integration', () => {
     const serviceWorkerContent = await readFile(SERVICE_WORKER_PATH, 'utf8');
     const builtServiceWorkerContent = serviceWorkerContent.replace(WASM_PLACEHOLDER, '`${BASE_PATH}/websl_bg.wasm`,');
 
-    expect(builtServiceWorkerContent).toMatch(/`\$\{BASE_PATH\}\/manifest\.json`,\s+`\$\{BASE_PATH\}\/websl_bg\.wasm`,/);
+    expect(builtServiceWorkerContent).toMatch(
+      /`\$\{BASE_PATH\}\/manifest\.json`,\s+`\$\{BASE_PATH\}\/websl_bg\.wasm`,/
+    );
   });
 });

--- a/apps/page/src/service-worker-navigation.test.ts
+++ b/apps/page/src/service-worker-navigation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { getNavigationCachePath, getNavigationFallbackPath } from './service-worker-navigation';
+import {
+  getNavigationCachePath,
+  getNavigationFallbackPath,
+  getNavigationRedirectPath
+} from './service-worker-navigation';
 
 describe('getNavigationCachePath', () => {
   test('normalizes root page requests to index.html', () => {
@@ -26,5 +30,17 @@ describe('getNavigationFallbackPath', () => {
 
   test('falls back to index shell for unknown routes', () => {
     expect(getNavigationFallbackPath('/sl', '/sl/unknown')).toBe('/sl/index.html');
+  });
+});
+
+describe('getNavigationRedirectPath', () => {
+  test('redirects bare project base paths to the canonical trailing-slash URL', () => {
+    expect(getNavigationRedirectPath('/sl', '/sl')).toBe('/sl/');
+  });
+
+  test('does not redirect already-canonical or unrelated paths', () => {
+    expect(getNavigationRedirectPath('/sl', '/sl/')).toBeNull();
+    expect(getNavigationRedirectPath('/sl', '/sl/embed')).toBeNull();
+    expect(getNavigationRedirectPath('', '/')).toBeNull();
   });
 });

--- a/apps/page/src/service-worker-navigation.ts
+++ b/apps/page/src/service-worker-navigation.ts
@@ -18,6 +18,19 @@ export const getNavigationCachePath = (basePath: string, pathname: string) => {
 };
 
 /**
+ * Returns the canonical navigation URL to redirect to before serving a cached
+ * document shell. Bare project base paths need a trailing slash so relative
+ * assets resolve underneath the project path.
+ */
+export const getNavigationRedirectPath = (basePath: string, pathname: string) => {
+  if (basePath && pathname === basePath) {
+    return `${basePath}/`;
+  }
+
+  return null;
+};
+
+/**
  * Returns the best offline shell to serve for a document route.
  * Unknown routes intentionally fall back to the main index shell.
  */

--- a/apps/page/src/service-worker.test.ts
+++ b/apps/page/src/service-worker.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+
+type ServiceWorkerListener = (event: unknown) => void;
+
+const listeners = new Map<string, ServiceWorkerListener>();
+const originalSelf = globalThis.self;
+const originalCaches = globalThis.caches;
+const originalFetch = globalThis.fetch;
+const originalRequest = globalThis.Request;
+
+let skipWaitingCalls = 0;
+let cacheOpenCalls = 0;
+let openCache = async () => ({}) as Cache;
+let fetchImpl = fetch;
+
+beforeAll(async () => {
+  Reflect.set(globalThis, 'self', {
+    location: {
+      origin: 'https://example.com',
+      pathname: '/sl/service-worker.js'
+    },
+    addEventListener: (type: string, listener: ServiceWorkerListener) => {
+      listeners.set(type, listener);
+    },
+    skipWaiting: () => {
+      skipWaitingCalls += 1;
+      return Promise.resolve();
+    },
+    clients: {
+      claim: () => Promise.resolve()
+    }
+  });
+
+  Reflect.set(globalThis, 'caches', {
+    open: async () => {
+      cacheOpenCalls += 1;
+      return openCache();
+    },
+    keys: async () => [],
+    delete: async () => true,
+    has: async () => false,
+    match: async () => undefined
+  } as unknown as CacheStorage);
+
+  Reflect.set(
+    globalThis,
+    'fetch',
+    Object.assign((input: RequestInfo | URL, init?: RequestInit) => fetchImpl(input, init), {
+      preconnect: Reflect.get(originalFetch as object, 'preconnect')
+    }) as unknown as typeof fetch
+  );
+
+  Reflect.set(
+    globalThis,
+    'Request',
+    class RequestWithBase extends Request {
+      constructor(input: RequestInfo | URL, init?: RequestInit) {
+        super(
+          typeof input === 'string' && input.startsWith('/') ? new URL(input, 'https://example.com').toString() : input,
+          init
+        );
+      }
+    }
+  );
+
+  await import(new URL(`./service-worker.ts?test=${Date.now()}`, import.meta.url).href);
+});
+
+afterAll(() => {
+  Reflect.set(globalThis, 'self', originalSelf);
+  Reflect.set(globalThis, 'caches', originalCaches);
+  Reflect.set(globalThis, 'fetch', originalFetch);
+  Reflect.set(globalThis, 'Request', originalRequest);
+});
+
+beforeEach(() => {
+  skipWaitingCalls = 0;
+  cacheOpenCalls = 0;
+  openCache = async () => ({}) as Cache;
+  fetchImpl = originalFetch;
+});
+
+describe('service worker regressions', () => {
+  test('rejects install when required precaching fails', async () => {
+    const installError = new Error('precache failed');
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
+    try {
+      openCache = async () =>
+        ({
+          addAll: async () => {
+            throw installError;
+          }
+        }) as unknown as Cache;
+
+      const installHandler = listeners.get('install');
+      expect(installHandler).toBeDefined();
+
+      let installPromise: Promise<unknown> | undefined;
+      installHandler?.({
+        waitUntil: (promise: Promise<unknown>) => {
+          installPromise = promise;
+        }
+      });
+
+      expect(installPromise).toBeDefined();
+      await expect(installPromise).rejects.toBe(installError);
+      expect(skipWaitingCalls).toBe(0);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  test('redirects offline bare project navigations to the canonical shell URL', async () => {
+    openCache = async () =>
+      ({
+        match: async () =>
+          new Response('<!doctype html>', {
+            headers: {
+              'Content-Type': 'text/html'
+            }
+          })
+      }) as unknown as Cache;
+    fetchImpl = (async () => {
+      throw new Error('offline');
+    }) as unknown as typeof fetch;
+
+    const fetchHandler = listeners.get('fetch');
+    expect(fetchHandler).toBeDefined();
+
+    let responsePromise: Promise<Response> | undefined;
+    fetchHandler?.({
+      request: {
+        destination: 'document',
+        method: 'GET',
+        mode: 'navigate',
+        url: 'https://example.com/sl'
+      },
+      respondWith: (promise: Promise<Response>) => {
+        responsePromise = promise;
+      }
+    });
+
+    expect(responsePromise).toBeDefined();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('https://example.com/sl/');
+    expect(cacheOpenCalls).toBe(0);
+  });
+});

--- a/apps/page/src/service-worker.ts
+++ b/apps/page/src/service-worker.ts
@@ -112,11 +112,9 @@ serviceWorker.addEventListener('activate', (event: ExtendableEventLike) => {
         });
       });
 
-      return Promise.all([deleteOldCaches, cleanupStaleAssets]);
+      return Promise.all([deleteOldCaches, cleanupStaleAssets, serviceWorker.clients.claim()]);
     })
   );
-  // Claim all clients immediately
-  serviceWorker.clients.claim();
 });
 
 // Fetch event - serve from cache or network

--- a/apps/page/src/service-worker.ts
+++ b/apps/page/src/service-worker.ts
@@ -1,4 +1,24 @@
-import { getNavigationCachePath, getNavigationFallbackPath } from './service-worker-navigation';
+import {
+  getNavigationCachePath,
+  getNavigationFallbackPath,
+  getNavigationRedirectPath
+} from './service-worker-navigation';
+
+type ExtendableEventLike = Event & {
+  waitUntil: (promise: Promise<unknown>) => void;
+};
+
+type FetchEventLike = ExtendableEventLike & {
+  request: Request;
+  respondWith: (response: Promise<Response> | Response) => void;
+};
+
+const serviceWorker = self as typeof self & {
+  skipWaiting: () => Promise<void>;
+  clients: {
+    claim: () => Promise<void>;
+  };
+};
 
 // Service Worker for offline support
 // Implements a network-first strategy with cache fallback for navigation
@@ -19,6 +39,7 @@ const getBasePath = () => {
 
 const BASE_PATH = getBasePath();
 
+// prettier-ignore
 const ASSETS_TO_CACHE = [
   `${BASE_PATH}/`,
   `${BASE_PATH}/index.html`,
@@ -44,7 +65,7 @@ const matchNavigationFallback = (cache: Cache, pathname: string) =>
   });
 
 // Install event - cache initial assets
-self.addEventListener('install', (event: ExtendableEvent) => {
+serviceWorker.addEventListener('install', (event: ExtendableEventLike) => {
   event.waitUntil(
     caches
       .open(CACHE_NAME)
@@ -55,14 +76,14 @@ self.addEventListener('install', (event: ExtendableEvent) => {
       })
       .catch((error) => {
         console.error('Service Worker: Failed to cache initial assets', error);
+        throw error;
       })
+      .then(() => serviceWorker.skipWaiting())
   );
-  // Force the waiting service worker to become the active service worker
-  self.skipWaiting();
 });
 
 // Activate event - clean up old caches
-self.addEventListener('activate', (event: ExtendableEvent) => {
+serviceWorker.addEventListener('activate', (event: ExtendableEventLike) => {
   event.waitUntil(
     caches.keys().then((cacheNames) => {
       const deleteOldCaches = Promise.all(
@@ -95,11 +116,11 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
     })
   );
   // Claim all clients immediately
-  self.clients.claim();
+  serviceWorker.clients.claim();
 });
 
 // Fetch event - serve from cache or network
-self.addEventListener('fetch', (event: FetchEvent) => {
+serviceWorker.addEventListener('fetch', (event: FetchEventLike) => {
   const { request } = event;
   const url = new URL(request.url);
 
@@ -143,6 +164,11 @@ self.addEventListener('fetch', (event: FetchEvent) => {
           return response;
         })
         .catch(() => {
+          const navigationRedirectPath = getNavigationRedirectPath(BASE_PATH, url.pathname);
+          if (navigationRedirectPath) {
+            return Response.redirect(new URL(navigationRedirectPath, self.location.origin).toString());
+          }
+
           // If network fails, try cache
           return caches.open(CACHE_NAME).then((cache) => {
             return cache.match(request).then((cachedResponse) => {

--- a/apps/page/take-screenshots.mjs
+++ b/apps/page/take-screenshots.mjs
@@ -1,0 +1,61 @@
+import { chromium } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const port = 4173;
+const baseURL = `http://127.0.0.1:${port}`;
+
+const waitForServiceWorkerControl = async (page) => {
+  await page.evaluate(async () => {
+    if (!('serviceWorker' in navigator)) {
+      throw new Error('Service workers are not supported in this browser');
+    }
+    await navigator.serviceWorker.ready;
+    if (navigator.serviceWorker.controller) {
+      return;
+    }
+    await new Promise((resolve) => {
+      navigator.serviceWorker.addEventListener('controllerchange', () => resolve(), { once: true });
+    });
+  });
+};
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({
+  baseURL,
+  serviceWorkers: 'allow',
+  viewport: { width: 1280, height: 800 }
+});
+const page = await context.newPage();
+
+// --- Online screenshot ---
+console.log('Navigating to /sl/ (online)...');
+await page.goto(`${baseURL}/sl/`, { waitUntil: 'networkidle' });
+
+// Wait for the train animation to appear (canvas or pre element with train)
+await page.waitForTimeout(2000);
+await page.screenshot({ path: path.join(__dirname, 'online.png'), fullPage: false });
+console.log('Online screenshot saved.');
+
+// Wait for service worker to take control
+await waitForServiceWorkerControl(page);
+console.log('Service worker is in control.');
+
+// --- Offline screenshot ---
+console.log('Going offline...');
+await context.setOffline(true);
+await page.reload({ waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(2000);
+await page.screenshot({ path: path.join(__dirname, 'offline.png'), fullPage: false });
+console.log('Offline screenshot saved.');
+
+// Also take offline embed screenshot
+const embedPage = await context.newPage();
+await embedPage.goto(`${baseURL}/sl/embed?train=D1&loop=true`, { waitUntil: 'domcontentloaded' });
+await embedPage.waitForTimeout(2000);
+await embedPage.screenshot({ path: path.join(__dirname, 'offline-embed.png'), fullPage: false });
+console.log('Offline embed screenshot saved.');
+
+await browser.close();
+console.log('Done!');

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "websl": "*",
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/bun": "1.3.3",
         "typescript": "^5.9.3",
       },
@@ -106,6 +107,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
 
@@ -284,6 +287,8 @@
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -468,6 +473,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test": "bun run test:websl && bun run test:page",
     "test:libsl": "cargo test --manifest-path libraries/libsl/Cargo.toml",
     "test:page": "bun run --cwd apps/page test",
+    "test:page:e2e": "bun run --cwd apps/page test:e2e",
     "test:websl": "bun run --cwd libraries/websl test",
     "test:websl:rust": "wasm-pack test --headless --firefox libraries/websl",
     "typecheck": "bun run typecheck:page",


### PR DESCRIPTION
## Summary
- fail service worker installation when required precache assets cannot be cached
- redirect bare /sl offline navigations to the canonical trailing-slash shell URL
- add Playwright-based offline validation for the page app

## Testing
- bun run build:websl
- bun run test:page
- bun run typecheck:page
- bun run test:page:e2e